### PR TITLE
Fix dark mode toggle label initialization

### DIFF
--- a/index.html
+++ b/index.html
@@ -234,18 +234,24 @@
   2025 Samuel Degen — Last updated August 2025
 </div>
 
-<button id="modeToggle">🌙 Dark Mode</button>
+<button id="modeToggle"></button>
 
 <script>
   const modeToggle = document.getElementById('modeToggle');
+
+  function updateModeToggleText() {
+    modeToggle.textContent = document.body.classList.contains('light-mode')
+      ? '🌙 Dark Mode'
+      : '☀️ Light Mode';
+  }
+
   modeToggle.addEventListener('click', () => {
     document.body.classList.toggle('light-mode');
-    if (document.body.classList.contains('light-mode')) {
-      modeToggle.textContent = '🌙 Dark Mode';
-    } else {
-      modeToggle.textContent = '☀️ Light Mode';
-    }
+    updateModeToggleText();
   });
+
+  // Set initial text based on current mode
+  updateModeToggleText();
 </script>
 
 </body>


### PR DESCRIPTION
## Summary
- ensure dark mode toggle button displays the correct label based on current theme

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689cd7b8b37483309b2d601a04760e0b