### PR TITLE
Add animated gradient background tokens for dark and light themes

### DIFF
--- a/index.html
+++ b/index.html
@@ -38,9 +38,9 @@
     html { scroll-behavior: smooth; }
     :root { 
       --bg-color: #3a3a3a;
-      --bg-grad-1: #1f2a44;
-      --bg-grad-2: #2a1f3f;
-      --bg-grad-3: #103235;
+      --bg-grad-1: #2a0066;
+      --bg-grad-2: #0f1233;
+      --bg-grad-3: #00d2d3;
       --bg-noise-opacity: 0.04;
       --text-color: #eaeaea;
       --section-bg: #1d1d1d;
@@ -56,9 +56,9 @@
     }
     body.light-mode {
       --bg-color: #ffffff;
-      --bg-grad-1: #f9fbff;
-      --bg-grad-2: #eef5ff;
-      --bg-grad-3: #f6f0ff;
+      --bg-grad-1: #ecf5ff;
+      --bg-grad-2: #f2ebff;
+      --bg-grad-3: #dcfbff;
       --bg-noise-opacity: 0.03;
       --text-color: #333333;
       --section-bg: #ffffff; /* pure white cards */
@@ -76,14 +76,22 @@
       margin: 0;
       background-color: var(--bg-color);
       background-image:
-        radial-gradient(circle at 12% 18%, color-mix(in srgb, var(--bg-grad-1) 92%, transparent) 0%, transparent 48%),
-        radial-gradient(circle at 84% 80%, color-mix(in srgb, var(--bg-grad-3) 88%, transparent) 0%, transparent 52%),
-        linear-gradient(135deg, var(--bg-grad-1), var(--bg-grad-2) 55%, var(--bg-grad-3));
+        radial-gradient(circle at 16% 84%, color-mix(in srgb, var(--bg-grad-3) 92%, transparent) 0%, transparent 48%),
+        radial-gradient(circle at 68% 0%, color-mix(in srgb, var(--bg-grad-1) 92%, transparent) 0%, transparent 44%),
+        radial-gradient(circle at 64% 56%, color-mix(in srgb, #000000 78%, transparent) 0%, transparent 50%),
+        linear-gradient(130deg, var(--bg-grad-2) 10%, color-mix(in srgb, var(--bg-grad-1) 72%, var(--bg-grad-2)) 56%, var(--bg-grad-2) 100%);
       background-size: 200% 200%;
       animation: bg-shift 18s ease-in-out infinite;
       color: var(--text-color);
       line-height: 1.6;
       transition: background-color 0.3s, color 0.3s;
+    }
+    body.light-mode {
+      background-image:
+        radial-gradient(circle at 18% 82%, color-mix(in srgb, var(--bg-grad-3) 72%, transparent) 0%, transparent 46%),
+        radial-gradient(circle at 74% 2%, color-mix(in srgb, var(--bg-grad-1) 72%, transparent) 0%, transparent 42%),
+        radial-gradient(circle at 65% 58%, rgba(255,255,255,0.35) 0%, transparent 54%),
+        linear-gradient(130deg, var(--bg-grad-2) 12%, var(--bg-grad-1) 56%, var(--bg-grad-3) 100%);
     }
     @keyframes bg-shift {
       0% { background-position: 0% 50%; }

--- a/index.html
+++ b/index.html
@@ -38,8 +38,12 @@
     html { scroll-behavior: smooth; }
     :root { 
       --bg-color: #3a3a3a;
+      --bg-grad-1: #1f2a44;
+      --bg-grad-2: #2a1f3f;
+      --bg-grad-3: #103235;
+      --bg-noise-opacity: 0.04;
       --text-color: #eaeaea;
-      --section-bg: #222222;
+      --section-bg: #1d1d1d;
       --accent-gradient: radial-gradient(circle, rgba(238,174,202,1) 0%, rgba(148,187,233,1) 100%);
       --nav-bg: #333333; /* pills */
       --nav-fg: #ffffff;
@@ -52,6 +56,10 @@
     }
     body.light-mode {
       --bg-color: #ffffff;
+      --bg-grad-1: #f9fbff;
+      --bg-grad-2: #eef5ff;
+      --bg-grad-3: #f6f0ff;
+      --bg-noise-opacity: 0.03;
       --text-color: #333333;
       --section-bg: #ffffff; /* pure white cards */
       --accent-gradient: radial-gradient(circle, rgba(238,174,202,1) 0%, rgba(148,187,233,1) 100%);
@@ -63,7 +71,28 @@
     }
 
     /* TYPOGRAPHY */
-    body { font-family: 'Calibre', 'Calibri', 'Helvetica Neue', Helvetica, Arial, system-ui, -apple-system, Segoe UI, sans-serif; margin: 0; background: var(--bg-color); color: var(--text-color); line-height: 1.6; transition: background 0.3s, color 0.3s; }
+    body {
+      font-family: 'Calibre', 'Calibri', 'Helvetica Neue', Helvetica, Arial, system-ui, -apple-system, Segoe UI, sans-serif;
+      margin: 0;
+      background-color: var(--bg-color);
+      background-image:
+        radial-gradient(circle at 12% 18%, color-mix(in srgb, var(--bg-grad-1) 92%, transparent) 0%, transparent 48%),
+        radial-gradient(circle at 84% 80%, color-mix(in srgb, var(--bg-grad-3) 88%, transparent) 0%, transparent 52%),
+        linear-gradient(135deg, var(--bg-grad-1), var(--bg-grad-2) 55%, var(--bg-grad-3));
+      background-size: 200% 200%;
+      animation: bg-shift 18s ease-in-out infinite;
+      color: var(--text-color);
+      line-height: 1.6;
+      transition: background-color 0.3s, color 0.3s;
+    }
+    @keyframes bg-shift {
+      0% { background-position: 0% 50%; }
+      50% { background-position: 100% 50%; }
+      100% { background-position: 0% 50%; }
+    }
+    @media (prefers-reduced-motion: reduce) {
+      body { animation: none; }
+    }
     main a {
       color: #225ee8;
       text-decoration-color: rgba(34, 94, 232, 0.5);


### PR DESCRIPTION
### Motivation
- Introduce a gentle animated background for both dark and light themes while preserving existing card and text contrast.
- Provide theme tokens so the `body.light-mode` class can continue swapping values cleanly for the theme toggle.
- Respect accessibility by allowing users who prefer reduced motion to disable the animation.

### Description
- Added new CSS variables in `:root` for dark-mode (`--bg-grad-1`, `--bg-grad-2`, `--bg-grad-3`, `--bg-noise-opacity`) and mirrored equivalents in `body.light-mode`.
- Replaced the flat `body` background with layered `background-image` gradients, set `background-size: 200% 200%;`, and added `animation: bg-shift 18s ease-in-out infinite`.
- Added `@keyframes bg-shift` for the animation and an `@media (prefers-reduced-motion: reduce)` rule to disable animation for reduced-motion users.
- Preserved `--section-bg` usage and slightly darkened dark-mode `--section-bg` to maintain card readability.

### Testing
- Printed and inspected the updated `index.html` content to confirm new variables, layered gradients, and `@keyframes bg-shift` are present (succeeded).
- Verified that only `index.html` was modified in the change set (succeeded).
- No browser or visual regression tests were executed in this run (not executed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c948b03a5083309cc70fcfa78efe9a)