### PR TITLE
Polish mobile portfolio experience

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,6 +3,8 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <meta name="theme-color" content="#09090b" id="themeColorMeta" />
+  <meta name="apple-mobile-web-app-status-bar-style" content="default" />
   <title>Samuel Degen | Theoretical Physics at UCLA</title>
   <meta name="title" content="Samuel Degen | Theoretical Physics at UCLA" />
   <meta name="description" content="Samuel Degen is a UCLA physics student advancing research at the intersection of quantum field theory, gravity, and nuclear physics. His work uses powerful modern tools from particle physics to improve theoretical predictions for next-generation experiments in gravitational waves and ultracold atoms. Select fellowships and international research opportunities highlight his potential as a future global scholar and a communicator who helps disseminate scientific advances across borders." />
@@ -1220,6 +1222,7 @@ ul li > .planned::after  { content: "]"; }
       font-size: 0;
       box-shadow: none;
       text-shadow: 0 2px 16px rgba(0,0,0,.34);
+      touch-action: manipulation;
       transition: transform .2s var(--ease), color .2s var(--ease), text-shadow .2s var(--ease);
     }
 
@@ -1318,7 +1321,7 @@ ul li > .planned::after  { content: "]"; }
 
     body.section-focus-ready section {
       animation: none;
-      transition: opacity .34s var(--ease), filter .34s var(--ease), transform .34s var(--ease);
+      transition: opacity .85s var(--ease), filter .85s var(--ease), transform .85s var(--ease);
     }
 
     body.section-focus-ready section.is-entry-soft {
@@ -1576,6 +1579,12 @@ ul li > .planned::after  { content: "]"; }
         display: initial;
       }
 
+      #summary p,
+      #research details p {
+        font-size: .93rem;
+        line-height: 1.58;
+      }
+
       section {
         padding: 20px 16px;
       }
@@ -1606,6 +1615,10 @@ ul li > .planned::after  { content: "]"; }
 
       #modeToggle .label {
         display: none;
+      }
+
+      #modeToggle {
+        bottom: 10px;
       }
     }
   </style>
@@ -2249,6 +2262,7 @@ ul li > .planned::after  { content: "]"; }
 <script>
   // Light/Dark mode toggle with monochrome SVG icons + text
   const modeToggle = document.getElementById('modeToggle');
+  const themeColorMeta = document.getElementById('themeColorMeta');
   const sunIcon = '<svg viewBox="0 0 24 24" aria-hidden="true"><circle cx="12" cy="12" r="4" fill="none" stroke="currentColor" stroke-width="1.5"/><g stroke="currentColor" stroke-width="1.5" stroke-linecap="round"><line x1="12" y1="2" x2="12" y2="5"/><line x1="12" y1="19" x2="12" y2="22"/><line x1="2" y1="12" x2="5" y2="12"/><line x1="19" y1="12" x2="22" y2="12"/><line x1="4.2" y1="4.2" x2="6.5" y2="6.5"/><line x1="17.5" y1="17.5" x2="19.8" y2="19.8"/><line x1="4.2" y1="19.8" x2="6.5" y2="17.5"/><line x1="17.5" y1="6.5" x2="19.8" y2="4.2"/></g></svg>';
   const moonIcon = '<svg viewBox="0 0 24 24" aria-hidden="true"><path d="M21 12.6A8.5 8.5 0 1 1 11.4 3 6.5 6.5 0 0 0 21 12.6z" fill="none" stroke="currentColor" stroke-width="1.5"/></svg>';
   const THEME_STORAGE_KEY = 'samueldegen-theme';
@@ -2278,12 +2292,19 @@ ul li > .planned::after  { content: "]"; }
     modeToggle.innerHTML = (isLight ? moonIcon : sunIcon) + '<span class="label">' + label + '</span>';
     modeToggle.setAttribute('aria-label', isLight ? 'Switch to dark mode' : 'Switch to light mode');
   }
+  function updateThemeColor(){
+    if (!themeColorMeta) return;
+    const isLight = document.body.classList.contains('light-mode');
+    themeColorMeta.setAttribute('content', isLight ? '#f6f2e9' : '#09090b');
+  }
 
   applyStoredTheme();
+  updateThemeColor();
   updateModeToggle();
   modeToggle.addEventListener('click', () => {
     document.body.classList.toggle('light-mode');
     persistTheme();
+    updateThemeColor();
     updateModeToggle();
   });
 
@@ -2393,6 +2414,20 @@ ul li > .planned::after  { content: "]"; }
   let index = N; // start on the first slide of the middle block
   let autoTimer = null;
   let isAnimating = false;
+  let animationUnlockTimer = null;
+
+  function finishCarouselAnimation(){
+    if (animationUnlockTimer) {
+      clearTimeout(animationUnlockTimer);
+      animationUnlockTimer = null;
+    }
+    isAnimating = false;
+  }
+
+  function armCarouselUnlock(){
+    if (animationUnlockTimer) clearTimeout(animationUnlockTimer);
+    animationUnlockTimer = setTimeout(finishCarouselAnimation, 900);
+  }
 
   function slideOffset(i){
     const s = slides[i];
@@ -2407,8 +2442,15 @@ ul li > .planned::after  { content: "]"; }
   }
   function setActive(i){ slides.forEach((el, k) => el.classList.toggle('active', k === i)); }
   function centerOn(i, animate=true){
-    if(!animate){ track.classList.add('no-anim'); }
-    else { track.classList.remove('no-anim'); isAnimating = true; }
+    if(!animate){
+      finishCarouselAnimation();
+      track.classList.add('no-anim');
+    }
+    else {
+      track.classList.remove('no-anim');
+      isAnimating = true;
+      armCarouselUnlock();
+    }
     const left = slideOffset(i);
     track.style.transform = `translate3d(${-left}px,0,0)`;
     setActive(i);
@@ -2428,8 +2470,9 @@ ul li > .planned::after  { content: "]"; }
     return target;
   }
 
-  function go(delta){
-    if (isAnimating) return;
+  function go(delta, force=false){
+    if (isAnimating && !force) return;
+    if (force) finishCarouselAnimation();
     let target = index + delta;
     target = prewrap(target); // ensure we are in the middle block before animating
     index = target;
@@ -2443,16 +2486,16 @@ ul li > .planned::after  { content: "]"; }
   window.addEventListener('load', () => { slides = Array.from(track.children); centerOn(index, false); startAuto(); });
   window.addEventListener('resize', () => centerOn(index, false));
 
-  track.addEventListener('transitionend', (e)=>{ if (e.target !== track || e.propertyName !== 'transform') return; isAnimating = false; });
+  track.addEventListener('transitionend', (e)=>{ if (e.target !== track || e.propertyName !== 'transform') return; finishCarouselAnimation(); });
 
   // Controls — keep autoscroll running after clicks
-  prevBtn.addEventListener('click', () => { go(-1); restartAuto(); });
-  nextBtn.addEventListener('click', () => { go(1); restartAuto(); });
+  prevBtn.addEventListener('click', () => { go(-1, true); restartAuto(); });
+  nextBtn.addEventListener('click', () => { go(1, true); restartAuto(); });
 
   // Touch swipe handling
   let sx=0, sy=0, st=0;
   viewport.addEventListener('touchstart', e=>{ if(!e.touches[0]) return; sx=e.touches[0].clientX; sy=e.touches[0].clientY; st=Date.now(); stopAuto(); }, {passive:true});
-  viewport.addEventListener('touchend', e=>{ const dx=(e.changedTouches[0]?.clientX||0)-sx; const dy=(e.changedTouches[0]?.clientY||0)-sy; const dt=Date.now()-st; const horiz = Math.abs(dx)>Math.abs(dy) && Math.abs(dx)>30 && dt<600; if(horiz){ go(dx<0?1:-1); } restartAuto(); }, {passive:true});
+  viewport.addEventListener('touchend', e=>{ const dx=(e.changedTouches[0]?.clientX||0)-sx; const dy=(e.changedTouches[0]?.clientY||0)-sy; const dt=Date.now()-st; const horiz = Math.abs(dx)>Math.abs(dy) && Math.abs(dx)>30 && dt<600; if(horiz){ go(dx<0?1:-1, true); } restartAuto(); }, {passive:true});
 </script>
 
 </body>


### PR DESCRIPTION
## Summary
- Harden the image carousel on mobile Safari so manual arrows/swipes recover if transition events are missed.
- Slow the section blur/focus transition and reduce mobile paragraph text size for About and Research Experience.
- Add Safari theme-color handling and move the mobile light/dark control slightly lower.

## Validation
- `git diff --check`
- local href/src/anchor check: `refs=62 missing_files=[] missing_anchors=[]`
- local mobile browser preview: carousel arrow advances slides, no console errors