### PR TITLE
Fix mobile theme toggle shadow

### DIFF
--- a/index.html
+++ b/index.html
@@ -1621,6 +1621,28 @@ ul li > .planned::after  { content: "]"; }
         bottom: 10px;
       }
     }
+
+    @media (hover: none), (pointer: coarse) {
+      #modeToggle {
+        box-shadow: none;
+        transition: background .25s ease;
+      }
+
+      #modeToggle:hover,
+      #modeToggle:focus-visible,
+      #modeToggle:active {
+        box-shadow: none;
+        transform: none;
+      }
+    }
+
+    @media (hover: hover) and (pointer: fine) {
+      #modeToggle:hover,
+      #modeToggle:focus-visible {
+        box-shadow: 0 8px 20px rgba(0,0,0,0.35);
+        transform: translateY(-1px);
+      }
+    }
   </style>
 </head>
 <body>


### PR DESCRIPTION
## Summary
- Keep the theme toggle hover shadow on desktop hover/fine-pointer devices.
- Suppress the sticky tap shadow on touch/coarse-pointer devices to avoid clipped shadows in mobile Safari.

## Validation
- `git diff --check`
- local href/src/anchor check: `refs=62 missing_files=[] missing_anchors=[]`
- local mobile preview confirmed the touch-specific shadow override is present